### PR TITLE
Hash collisions for strings with MAX_LENGTH characters

### DIFF
--- a/src/StringHasher.php
+++ b/src/StringHasher.php
@@ -21,7 +21,7 @@ class StringHasher  {
 	/**
 	 * Returns a version of the string with maximum length 50.
 	 * The first 30 characters of the string are kept as-is in all cases.
-	 * If the string exceeds the max length, the end of the space is
+	 * If the string reaches the max length, the end of the space is
 	 * used for a hash that ensures uniqueness.
 	 *
 	 * @param string $string
@@ -34,7 +34,7 @@ class StringHasher  {
 			throw new InvalidArgumentException( '$string should be a string' );
 		}
 
-		if ( strlen( $string ) > $this->MAX_LENGTH ) {
+		if ( strlen( $string ) >= $this->MAX_LENGTH ) {
 			return substr( $string, 0, $this->PLAIN_LENGTH )
 				. substr( sha1( $string ), 0, $this->SHA_LENGTH );
 		}


### PR DESCRIPTION
In the new test I added the two input strings
- `"012345678901234567890123456789012345678901234567890"` and
- `"012345678901234567890123456789dae077f0a9dbf13cea96"`

both resulted in the same hash (because the first was hashed and became the second, but the second was returned as it was). I'm using the most simple metric to detect strings that possibly collide with hashes: their length. An other valid solution would be something like `if ( strlen( ... ) > 50 || ( strlen( ... ) === 50 && preg_match( '/[\da-f]{20}$/', ... ) ) )` but that's obviously overkill.
