### PR TITLE
Don't include base characters twice in hash

### DIFF
--- a/src/StringHasher.php
+++ b/src/StringHasher.php
@@ -36,7 +36,7 @@ class StringHasher  {
 
 		if ( strlen( $string ) >= $this->MAX_LENGTH ) {
 			return substr( $string, 0, $this->PLAIN_LENGTH )
-				. substr( sha1( $string ), 0, $this->SHA_LENGTH );
+				. substr( sha1( substr( $string, $this->PLAIN_LENGTH ) ), 0, $this->SHA_LENGTH );
 		}
 
 		return $string;

--- a/tests/Phpunit/StringHasherTest.php
+++ b/tests/Phpunit/StringHasherTest.php
@@ -74,4 +74,12 @@ class StringHasherTest extends \PHPUnit_Framework_TestCase {
 		$this->assertNotEquals( $hash0, $hash1 );
 	}
 
+	public function testGivenStringWithoutBaseIsTheSame_hashWithoutBaseIsTheSame() {
+		$maxString = str_pad( '', $this->MAX_LENGTH, '0123456789' );
+		$hash0 = $this->hasher->hash( 'a' . $maxString );
+		$hash1 = $this->hasher->hash( 'b' . $maxString );
+
+		$this->assertEquals( substr( $hash0, 1 ), substr( $hash1, 1 ) );
+	}
+
 }


### PR DESCRIPTION
What I mean with "twice": The first 30 characters are copied _and_ included in the calculation of the last 20 characters. Changing a bit in the first 30 characters of an input string causes two changes in the result: one in the first 30 and one in the last 20 characters. What I expect instead: Two strings that share the same appendix should result in two hashes that also share the same appendix.

Use case: The order of
- `"a00000000000000000000000000000000000000000000000001"` and
- `"a00000000000000000000000000000000000000000000000002"` should be the same as the order of
- `"b00000000000000000000000000000000000000000000000001"` and
- `"b00000000000000000000000000000000000000000000000002"` (not necessary in ascending order, but the same order anyway).
