### PR TITLE
Drop newDataValueFromValueField

### DIFF
--- a/src/SQLStore/DVHandler/BooleanHandler.php
+++ b/src/SQLStore/DVHandler/BooleanHandler.php
@@ -43,13 +43,6 @@ class BooleanHandler extends DataValueHandler {
 	}
 
 	/**
-	 * @see DataValueHandler::newDataValueFromValueField
-	 */
-	public function newDataValueFromValueField( $valueFieldValue ) {
-		return new BooleanValue( $valueFieldValue );
-	}
-
-	/**
 	 * @see DataValueHandler::getInsertValues
 	 *
 	 * @param DataValue $value

--- a/src/SQLStore/DVHandler/EntityIdHandler.php
+++ b/src/SQLStore/DVHandler/EntityIdHandler.php
@@ -50,18 +50,6 @@ class EntityIdHandler extends DataValueHandler {
 	}
 
 	/**
-	 * @see DataValueHandler::newDataValueFromValueField
-	 *
-	 * @param string $valueFieldValue
-	 *
-	 * @return DataValue
-	 */
-	public function newDataValueFromValueField( $valueFieldValue ) {
-		// TODO: handle parse exception
-		return new EntityIdValue( $this->idParser->parse( $valueFieldValue ) );
-	}
-
-	/**
 	 * @see DataValueHandler::getInsertValues
 	 *
 	 * @param DataValue $value

--- a/src/SQLStore/DVHandler/IriHandler.php
+++ b/src/SQLStore/DVHandler/IriHandler.php
@@ -62,17 +62,6 @@ class IriHandler extends DataValueHandler {
 	}
 
 	/**
-	 * @see DataValueHandler::newDataValueFromValueField
-	 *
-	 * @param string $valueFieldValue
-	 *
-	 * @return DataValue
-	 */
-	public function newDataValueFromValueField( $valueFieldValue ) {
-		return IriValue::newFromArray( json_decode( $valueFieldValue, true ) );
-	}
-
-	/**
 	 * @see DataValueHandler::getInsertValues
 	 *
 	 * @param DataValue $value

--- a/src/SQLStore/DVHandler/LatLongHandler.php
+++ b/src/SQLStore/DVHandler/LatLongHandler.php
@@ -47,18 +47,6 @@ class LatLongHandler extends DataValueHandler {
 	}
 
 	/**
-	 * @see DataValueHandler::newDataValueFromValueField
-	 *
-	 * @param string $valueFieldValue
-	 *
-	 * @return DataValue
-	 */
-	public function newDataValueFromValueField( $valueFieldValue ) {
-		$value = explode( '|', $valueFieldValue, 2 );
-		return new LatLongValue( (float)$value[0], (float)$value[1] );
-	}
-
-	/**
 	 * @see DataValueHandler::getInsertValues
 	 *
 	 * @param DataValue $value

--- a/src/SQLStore/DVHandler/MonolingualTextHandler.php
+++ b/src/SQLStore/DVHandler/MonolingualTextHandler.php
@@ -74,17 +74,6 @@ class MonolingualTextHandler extends DataValueHandler {
 	}
 
 	/**
-	 * @see DataValueHandler::newDataValueFromValueField
-	 *
-	 * @param string $valueFieldValue
-	 *
-	 * @return DataValue
-	 */
-	public function newDataValueFromValueField( $valueFieldValue ) {
-		return MonolingualTextValue::newFromArray( json_decode( $valueFieldValue, true ) );
-	}
-
-	/**
 	 * @see DataValueHandler::getInsertValues
 	 *
 	 * @param DataValue $value

--- a/src/SQLStore/DVHandler/NumberHandler.php
+++ b/src/SQLStore/DVHandler/NumberHandler.php
@@ -42,17 +42,6 @@ class NumberHandler extends DataValueHandler {
 	}
 
 	/**
-	 * @see DataValueHandler::newDataValueFromValueField
-	 *
-	 * @param string $valueFieldValue
-	 *
-	 * @return DataValue
-	 */
-	public function newDataValueFromValueField( $valueFieldValue ) {
-		return new NumberValue( $valueFieldValue );
-	}
-
-	/**
 	 * @see DataValueHandler::getInsertValues
 	 *
 	 * @param DataValue $value

--- a/src/SQLStore/DVHandler/StringHandler.php
+++ b/src/SQLStore/DVHandler/StringHandler.php
@@ -65,17 +65,6 @@ class StringHandler extends DataValueHandler {
 	}
 
 	/**
-	 * @see DataValueHandler::newDataValueFromValueField
-	 *
-	 * @param string $valueFieldValue
-	 *
-	 * @return DataValue
-	 */
-	public function newDataValueFromValueField( $valueFieldValue ) {
-		return new StringValue( $valueFieldValue );
-	}
-
-	/**
 	 * @see DataValueHandler::getInsertValues
 	 *
 	 * @param DataValue $value

--- a/src/SQLStore/DataValueHandler.php
+++ b/src/SQLStore/DataValueHandler.php
@@ -141,19 +141,6 @@ abstract class DataValueHandler {
 	}
 
 	/**
-	 * Create a DataValue from a cell value in the tables value field.
-	 *
-	 * @since 0.1
-	 *
-	 * @param string $valueFieldValue
-	 *
-	 * @return DataValue
-	 *
-	 * TODO: exception type
-	 */
-	abstract public function newDataValueFromValueField( $valueFieldValue );
-
-	/**
 	 * Return an array of fields=>values that is to be inserted when
 	 * writing the given DataValue to the database. Values should be set
 	 * for all columns, even if NULL. This array is used to perform all

--- a/tests/Phpunit/SQLStore/DataValueHandlerTest.php
+++ b/tests/Phpunit/SQLStore/DataValueHandlerTest.php
@@ -107,25 +107,6 @@ abstract class DataValueHandlerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider valueProvider
-	 *
-	 * @param DataValue $value
-	 */
-	public function testNewDataValueFromValueFieldValue( DataValue $value ) {
-		$instance = $this->newInstance();
-
-		$fieldValues = $instance->getInsertValues( $value );
-		$valueFieldValue = $fieldValues[$instance->getValueFieldName()];
-
-		$newValue = $instance->newDataValueFromValueField( $valueFieldValue );
-
-		$this->assertTrue(
-			$value->equals( $newValue ),
-			'Newly constructed DataValue equals the old one'
-		);
-	}
-
-	/**
 	 * @dataProvider instanceProvider
 	 *
 	 * @param DataValueHandler $dvHandler


### PR DESCRIPTION
Storing the full value and having a reverse operation to get the full value from the query store is unnecessary and problematic for several reasons.

I would like to refactor this in multiple small steps. More are to follow.
