### PR TITLE
Default getEqualityFieldValue to DataValue::getHash

### DIFF
--- a/src/SQLStore/DataValueHandler.php
+++ b/src/SQLStore/DataValueHandler.php
@@ -183,6 +183,8 @@ abstract class DataValueHandler {
 	 * @return mixed
 	 * @throws InvalidArgumentException
 	 */
-	abstract public function getEqualityFieldValue( DataValue $value );
+	public function getEqualityFieldValue( DataValue $value ) {
+		return $value->getHash();
+	}
 
 }


### PR DESCRIPTION
I was wondering. Wouldn't this be the most simple solution? Use the hash for equality checks by default? Then, in addition to (or better instead of) overwriting the `getEqualityFieldValue` method in the DataValueHandler, we can overwrite the `getHash` method in the DataValue if this makes sense (depends on the type).
