### PR TITLE
Add equality field roundtrip test

### DIFF
--- a/tests/Phpunit/SQLStore/DataValueHandlerTest.php
+++ b/tests/Phpunit/SQLStore/DataValueHandlerTest.php
@@ -145,6 +145,23 @@ abstract class DataValueHandlerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @dataProvider valueProvider
+	 *
+	 * @param DataValue $value
+	 */
+	public function testGetEqualityFieldValue_matchesEqualityField( DataValue $value ) {
+		$instance = $this->newInstance();
+
+		$insertValues = $instance->getInsertValues( $value );
+		$equalityFieldName = $instance->getEqualityFieldName();
+		$equalityFieldValue = $instance->getEqualityFieldValue( $value );
+
+		$this->assertInternalType( 'array', $insertValues );
+		$this->assertArrayHasKey( $equalityFieldName, $insertValues );
+		$this->assertEquals( $insertValues[$equalityFieldName], $equalityFieldValue );
+	}
+
+	/**
 	 * @dataProvider instanceProvider
 	 *
 	 * @param DataValueHandler $dvHandler


### PR DESCRIPTION
This test was missing. TimeHandler actually violates the requirement that the values in the `getEqualityFieldName` field can be queried by comparing with a value from `getEqualityFieldValue`.

~~Should be merged before #21.~~ To late. :-(
