### PR TITLE
Reimplemented getEqualityFieldValue

### DIFF
--- a/tests/Phpunit/SQLStore/DVHandler/TimeHandlerTest.php
+++ b/tests/Phpunit/SQLStore/DVHandler/TimeHandlerTest.php
@@ -95,4 +95,51 @@ class TimeHandlerTest extends DataValueHandlerTest {
 		$this->assertGreaterThan( $insertValues['value_timestamp'], $insertValues['value_max_timestamp'] );
 	}
 
+	public function isoTimeProvider() {
+		return array(
+			// Strip plus sign and leading zeros
+			array( '2001-02-03T04:05:06Z', '+00002001-02-03T04:05:06Z' ),
+
+			// Attach actual time zone if not zero
+			array( '2001-02-03T04:05:06+00:59', '+00002001-02-03T04:05:06Z', 59 ),
+			array( '2001-02-03T04:05:06+01:00', '+00002001-02-03T04:05:06Z', 60 ),
+			array( '2001-02-03T04:05:06-01:01', '+00002001-02-03T04:05:06Z', -61 ),
+			array( '2001-02-03T04:05:06-100:00', '+00002001-02-03T04:05:06Z', -6000 ),
+
+			// Keep minus sign on negative years
+			array( '-2001-02-03T04:05:06Z', '-00002001-02-03T04:05:06Z' ),
+
+			// No four digit years
+			array( '1-02-03T04:05:06Z', '+00000001-02-03T04:05:06Z' ),
+			array( '-1-02-03T04:05:06Z', '-00000001-02-03T04:05:06Z' ),
+
+			// Make sure 32 bit integer clipping does not happen
+			array( '100000000000000-02-03T04:05:06Z', '+100000000000000-02-03T04:05:06Z' ),
+			array( '-100000000000000-02-03T04:05:06Z', '-100000000000000-02-03T04:05:06Z' ),
+		);
+	}
+
+	/**
+	 * @dataProvider isoTimeProvider
+	 *
+	 * @param string $expectedIsoTime
+	 * @param string $time an ISO 8601 date and time
+	 * @param int $timezone offset from UTC in minutes
+	 */
+	public function testGetEqualityFieldValue( $expectedIsoTime, $time, $timezone = 0 ) {
+		$instance = $this->newInstance();
+
+		$timeValue = new TimeValue(
+			$time,
+			$timezone,
+			0,
+			0,
+			TimeValue::PRECISION_SECOND,
+			'http://www.wikidata.org/entity/Q1985727'
+		);
+		$equalityFieldValue = $instance->getEqualityFieldValue( $timeValue );
+
+		$this->assertEquals( $expectedIsoTime, $equalityFieldValue );
+	}
+
 }


### PR DESCRIPTION
I decided to reimplement `getEqualityFieldValue` completely.

This change also makes the field useful for a potential reimplementation of `newDataValueFromValueField` (see #45), compared to using the default implementation of an MD5 hash.

Pretty simple rule:
- Just make it an ISO time stamp
- with no plus
- and no leading zeros (both don't add information).
- Replace the `Z` with the actual time zone.
- Drop the calendar model. If there are two identical looking dates in Gregorian and Julian, both will be found. Better than none found. The field is not required to be unique, or is it?
- Drop before and after. Not useful in equality checks. If I'm searching for a date I can't necessarily know what strange before and after values were entered when the value was created. It may be `-10` with `PRECISION_10a` while I'm searching for `-10` in years. The most straight-forward way to solve this is to just ignore the precision. That's what the min and max fields are for.

By the way, there is currently no way to query the min and max fields.
