### PR TITLE
Order coordinates by longitude, latitude

### DIFF
--- a/src/SQLStore/DVHandler/LatLongHandler.php
+++ b/src/SQLStore/DVHandler/LatLongHandler.php
@@ -35,8 +35,7 @@ class LatLongHandler extends DataValueHandler {
 		$table->addColumn( 'value_lon', Type::DECIMAL );
 		$table->addColumn( 'value', Type::STRING, array( 'length' => 100 ) );
 
-		$table->addIndex( array( 'value_lat' ) );
-		$table->addIndex( array( 'value_lon' ) );
+		$table->addIndex( array( 'value_lon', 'value_lat' ) );
 	}
 
 	/**


### PR DESCRIPTION
Ordering by a "latitude|longitude" string works but is not optimal, obviously. I think it's better to
- ... order by the decimal numbers instead of the string. This should be obvious.
- ... order by longitude first instead of latitude. This fits a little bit better to the shapes of the continents and the projections we are usually using. Coordinates will appear grouped: North America, South America, Europe/Africa, Asia. I think this is better than South-North.
