### PR TITLE
Drop duplicated addMatchConditions code

### DIFF
--- a/src/SQLStore/DVHandler/BooleanHandler.php
+++ b/src/SQLStore/DVHandler/BooleanHandler.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use InvalidArgumentException;
-use Wikibase\QueryEngine\QueryNotSupportedException;
 use Wikibase\QueryEngine\SQLStore\DataValueHandler;
 
 /**
@@ -79,25 +78,6 @@ class BooleanHandler extends DataValueHandler {
 		}
 
 		return $value->getValue();
-	}
-
-	/**
-	 * @see DataValueHandler::addMatchConditions
-	 *
-	 * @param QueryBuilder $builder
-	 * @param ValueDescription $description
-	 *
-	 * @return array
-	 * @throws InvalidArgumentException
-	 * @throws QueryNotSupportedException
-	 */
-	public function addMatchConditions( QueryBuilder $builder, ValueDescription $description ) {
-		if ( $description->getComparator() === ValueDescription::COMP_EQUAL ) {
-			$this->addEqualityMatchConditions( $builder, $description->getValue() );
-		}
-		else {
-			throw new QueryNotSupportedException( $description, 'Only equality is supported' );
-		}
 	}
 
 }

--- a/src/SQLStore/DVHandler/EntityIdHandler.php
+++ b/src/SQLStore/DVHandler/EntityIdHandler.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Types\Type;
 use InvalidArgumentException;
 use Wikibase\DataModel\Entity\EntityIdParser;
 use Wikibase\DataModel\Entity\EntityIdValue;
-use Wikibase\QueryEngine\QueryNotSupportedException;
 use Wikibase\QueryEngine\SQLStore\DataValueHandler;
 
 /**
@@ -87,25 +86,6 @@ class EntityIdHandler extends DataValueHandler {
 		}
 
 		return $value->getEntityId()->getSerialization();
-	}
-
-	/**
-	 * @see DataValueHandler::addMatchConditions
-	 *
-	 * @param QueryBuilder $builder
-	 * @param ValueDescription $description
-	 *
-	 * @return array
-	 * @throws InvalidArgumentException
-	 * @throws QueryNotSupportedException
-	 */
-	public function addMatchConditions( QueryBuilder $builder, ValueDescription $description ) {
-		if ( $description->getComparator() === ValueDescription::COMP_EQUAL ) {
-			$this->addEqualityMatchConditions( $builder, $description->getValue() );
-		}
-		else {
-			throw new QueryNotSupportedException( $description, 'Only equality is supported' );
-		}
 	}
 
 }

--- a/src/SQLStore/DVHandler/IriHandler.php
+++ b/src/SQLStore/DVHandler/IriHandler.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use InvalidArgumentException;
-use Wikibase\QueryEngine\QueryNotSupportedException;
 use Wikibase\QueryEngine\SQLStore\DataValueHandler;
 
 /**
@@ -105,25 +104,6 @@ class IriHandler extends DataValueHandler {
 		}
 
 		return json_encode( $value->getArrayValue() );
-	}
-
-	/**
-	 * @see DataValueHandler::addMatchConditions
-	 *
-	 * @param QueryBuilder $builder
-	 * @param ValueDescription $description
-	 *
-	 * @return array
-	 * @throws InvalidArgumentException
-	 * @throws QueryNotSupportedException
-	 */
-	public function addMatchConditions( QueryBuilder $builder, ValueDescription $description ) {
-		if ( $description->getComparator() === ValueDescription::COMP_EQUAL ) {
-			$this->addEqualityMatchConditions( $builder, $description->getValue() );
-		}
-		else {
-			throw new QueryNotSupportedException( $description, 'Only equality is supported' );
-		}
 	}
 
 }

--- a/src/SQLStore/DVHandler/LatLongHandler.php
+++ b/src/SQLStore/DVHandler/LatLongHandler.php
@@ -98,7 +98,6 @@ class LatLongHandler extends DataValueHandler {
 	 * @param QueryBuilder $builder
 	 * @param ValueDescription $description
 	 *
-	 * @return array
 	 * @throws InvalidArgumentException
 	 * @throws QueryNotSupportedException
 	 */

--- a/src/SQLStore/DVHandler/MonolingualTextHandler.php
+++ b/src/SQLStore/DVHandler/MonolingualTextHandler.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use InvalidArgumentException;
-use Wikibase\QueryEngine\QueryNotSupportedException;
 use Wikibase\QueryEngine\SQLStore\DataValueHandler;
 use Wikibase\QueryEngine\StringHasher;
 
@@ -122,25 +121,6 @@ class MonolingualTextHandler extends DataValueHandler {
 		}
 
 		return $this->stringHasher->hash( $string );
-	}
-
-	/**
-	 * @see DataValueHandler::addMatchConditions
-	 *
-	 * @param QueryBuilder $builder
-	 * @param ValueDescription $description
-	 *
-	 * @return array
-	 * @throws InvalidArgumentException
-	 * @throws QueryNotSupportedException
-	 */
-	public function addMatchConditions( QueryBuilder $builder, ValueDescription $description ) {
-		if ( $description->getComparator() === ValueDescription::COMP_EQUAL ) {
-			$this->addEqualityMatchConditions( $builder, $description->getValue() );
-		}
-		else {
-			throw new QueryNotSupportedException( $description, 'Only equality is supported' );
-		}
 	}
 
 }

--- a/src/SQLStore/DVHandler/NumberHandler.php
+++ b/src/SQLStore/DVHandler/NumberHandler.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use InvalidArgumentException;
-use Wikibase\QueryEngine\QueryNotSupportedException;
 use Wikibase\QueryEngine\SQLStore\DataValueHandler;
 
 /**
@@ -78,25 +77,6 @@ class NumberHandler extends DataValueHandler {
 		}
 
 		return $value->getValue();
-	}
-
-	/**
-	 * @see DataValueHandler::addMatchConditions
-	 *
-	 * @param QueryBuilder $builder
-	 * @param ValueDescription $description
-	 *
-	 * @return array
-	 * @throws InvalidArgumentException
-	 * @throws QueryNotSupportedException
-	 */
-	public function addMatchConditions( QueryBuilder $builder, ValueDescription $description ) {
-		if ( $description->getComparator() === ValueDescription::COMP_EQUAL ) {
-			$this->addEqualityMatchConditions( $builder, $description->getValue() );
-		}
-		else {
-			throw new QueryNotSupportedException( $description, 'Only equality is supported' );
-		}
 	}
 
 }

--- a/src/SQLStore/DVHandler/StringHandler.php
+++ b/src/SQLStore/DVHandler/StringHandler.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use InvalidArgumentException;
-use Wikibase\QueryEngine\QueryNotSupportedException;
 use Wikibase\QueryEngine\SQLStore\DataValueHandler;
 use Wikibase\QueryEngine\StringHasher;
 
@@ -110,25 +109,6 @@ class StringHandler extends DataValueHandler {
 		}
 
 		return $this->stringHasher->hash( $string );
-	}
-
-	/**
-	 * @see DataValueHandler::addMatchConditions
-	 *
-	 * @param QueryBuilder $builder
-	 * @param ValueDescription $description
-	 *
-	 * @return array
-	 * @throws InvalidArgumentException
-	 * @throws QueryNotSupportedException
-	 */
-	public function addMatchConditions( QueryBuilder $builder, ValueDescription $description ) {
-		if ( $description->getComparator() === ValueDescription::COMP_EQUAL ) {
-			$this->addEqualityMatchConditions( $builder, $description->getValue() );
-		}
-		else {
-			throw new QueryNotSupportedException( $description, 'Only equality is supported' );
-		}
 	}
 
 }

--- a/src/SQLStore/DVHandler/TimeHandler.php
+++ b/src/SQLStore/DVHandler/TimeHandler.php
@@ -145,7 +145,6 @@ class TimeHandler extends DataValueHandler {
 	 * @param QueryBuilder $builder
 	 * @param ValueDescription $description
 	 *
-	 * @return array
 	 * @throws InvalidArgumentException
 	 * @throws QueryNotSupportedException
 	 */

--- a/src/SQLStore/DataValueHandler.php
+++ b/src/SQLStore/DataValueHandler.php
@@ -182,21 +182,17 @@ abstract class DataValueHandler {
 	 * @param QueryBuilder $builder
 	 * @param ValueDescription $description
 	 *
-	 * @return array
 	 * @throws InvalidArgumentException
 	 * @throws QueryNotSupportedException
 	 */
-	public abstract function addMatchConditions( QueryBuilder $builder, ValueDescription $description );
-
-	/**
-	 * @since 0.2
-	 *
-	 * @param QueryBuilder $builder
-	 * @param DataValue $value
-	 */
-	protected function addEqualityMatchConditions( QueryBuilder $builder, DataValue $value ) {
-		$builder->andWhere( $this->getTableName() . '.' . $this->getEqualityFieldName() . '= :equality' );
-		$builder->setParameter( ':equality', $this->getEqualityFieldValue( $value ) );
+	public function addMatchConditions( QueryBuilder $builder, ValueDescription $description ) {
+		if ( $description->getComparator() === ValueDescription::COMP_EQUAL ) {
+			$builder->andWhere( $this->getTableName() . '.' . $this->getEqualityFieldName() . '= :equality' );
+			$builder->setParameter( ':equality', $this->getEqualityFieldValue( $description->getValue() ) );
+		}
+		else {
+			throw new QueryNotSupportedException( $description, 'Only equality is supported' );
+		}
 	}
 
 }

--- a/src/SQLStore/Engine/DescriptionMatchFinder.php
+++ b/src/SQLStore/Engine/DescriptionMatchFinder.php
@@ -37,10 +37,12 @@ class DescriptionMatchFinder {
 	private $propertyDataValueTypeLookup;
 	private $idParser;
 
-	public function __construct( Connection $connection,
-			StoreSchema $schema,
-			PropertyDataValueTypeLookup $propertyDataValueTypeLookup, EntityIdParser $idParser ) {
-
+	public function __construct(
+		Connection $connection,
+		StoreSchema $schema,
+		PropertyDataValueTypeLookup $propertyDataValueTypeLookup,
+		EntityIdParser $idParser
+	) {
 		$this->connection = $connection;
 		$this->schema = $schema;
 		$this->propertyDataValueTypeLookup = $propertyDataValueTypeLookup;
@@ -137,7 +139,7 @@ class DescriptionMatchFinder {
 	}
 
 	/**
-	 * @param Iterator|array $resultRows
+	 * @param Iterator|array[] $resultRows
 	 *
 	 * @return EntityId[]
 	 */
@@ -155,4 +157,3 @@ class DescriptionMatchFinder {
 	}
 
 }
-


### PR DESCRIPTION
I found the structure of this new code counterintuitive and confusing.
- All handlers implement `addMatchConditions`, but they are all exact copies.
- All these individual methods call `$this->addEqualityMatchConditions` which is a default implementation in the parent.

So why not just make `addMatchConditions` having a default implementation? It's still the exact same interface but avoids a lot of code duplication. Every handler is still free to override the default implementation as the LatLong and Time handlers already do.
