### PR TITLE
Drop wrong equality implementation in Time

### DIFF
--- a/tests/Phpunit/SQLStore/DVHandler/TimeHandlerTest.php
+++ b/tests/Phpunit/SQLStore/DVHandler/TimeHandlerTest.php
@@ -24,8 +24,6 @@ class TimeHandlerTest extends DataValueHandlerTest {
 	/**
 	 * @see DataValueHandlerTest::getInstances
 	 *
-	 * @since 0.1
-	 *
 	 * @return DataValueHandler[]
 	 */
 	protected function getInstances() {
@@ -38,8 +36,6 @@ class TimeHandlerTest extends DataValueHandlerTest {
 
 	/**
 	 * @see DataValueHandlerTest::getValues
-	 *
-	 * @since 0.1
 	 *
 	 * @return TimeValue[]
 	 */


### PR DESCRIPTION
Use the default hash. The human readable hash I implemented missed the calendar model, before, after and precision. I don't think it's useful for anything: Sorting? No. Prefix search? Doesn't make sense, you do range searches.
