### PR TITLE
Drop DECIMAL from LatLongHandler

### DIFF
--- a/src/SQLStore/DVHandler/LatLongHandler.php
+++ b/src/SQLStore/DVHandler/LatLongHandler.php
@@ -38,8 +38,8 @@ class LatLongHandler extends DataValueHandler {
 	 * @param Table $table
 	 */
 	protected function completeTable( Table $table ) {
-		$table->addColumn( 'value_lat', Type::DECIMAL );
-		$table->addColumn( 'value_lon', Type::DECIMAL );
+		$table->addColumn( 'value_lat', Type::FLOAT );
+		$table->addColumn( 'value_lon', Type::FLOAT );
 		$table->addColumn( 'hash', Type::STRING, array( 'length' => 32 ) );
 
 		// We need to search for greater/lower than. This can't use a combined index.


### PR DESCRIPTION
Discussed with @brightbyte and came to the conclusion that we just can not use `DECIMAL`. It's a fixed point type that needs a fixed amount of decimal places before and after the comma. It's pretty much useless for what we do.
