### PR TITLE
Add comment to empty catch

### DIFF
--- a/src/SQLStore/Engine/DescriptionMatchFinder.php
+++ b/src/SQLStore/Engine/DescriptionMatchFinder.php
@@ -111,7 +111,7 @@ class DescriptionMatchFinder {
 			$dvHandler
 		);
 
-		$queryBuilder->andWhere( $dvHandler->getTableName() . '.' . 'property_id= :property_id' );
+		$queryBuilder->andWhere( $dvHandler->getTableName() . '.property_id = :property_id' );
 		$queryBuilder->setParameter( ':property_id', $propertyId->getSerialization() );
 
 		$dvHandler->addMatchConditions( $queryBuilder, $description );
@@ -148,7 +148,9 @@ class DescriptionMatchFinder {
 			try {
 				$entityIds[] = $this->idParser->parse( $resultRow['subject_id'] );
 			}
-			catch ( EntityIdParsingException $ex ) {}
+			catch ( EntityIdParsingException $ex ) {
+				// Reporting invalid IDs would not be helpful at this point, just skip them.
+			}
 		}
 
 		return $entityIds;


### PR DESCRIPTION
This fixes a problem Scrutinizer complaints about, see https://scrutinizer-ci.com/g/wmde/WikibaseQueryEngine/issues/master/files/src/SQLStore/Engine/DescriptionMatchFinder.php.
