### PR TITLE
Fix BooleanHandler for PostgreSQL

### DIFF
--- a/src/SQLStore/DVHandler/BooleanHandler.php
+++ b/src/SQLStore/DVHandler/BooleanHandler.php
@@ -52,8 +52,8 @@ class BooleanHandler extends DataValueHandler {
 	 *
 	 * @param DataValue $value
 	 *
-	 * @return array
 	 * @throws InvalidArgumentException
+	 * @return array
 	 */
 	public function getInsertValues( DataValue $value ) {
 		if ( !( $value instanceof BooleanValue ) ) {
@@ -61,7 +61,7 @@ class BooleanHandler extends DataValueHandler {
 		}
 
 		$values = array(
-			'value' => $value->getValue(),
+			'value' => $value->getValue() ? 1 : 0,
 		);
 
 		return $values;
@@ -72,15 +72,15 @@ class BooleanHandler extends DataValueHandler {
 	 *
 	 * @param DataValue $value
 	 *
-	 * @return string
 	 * @throws InvalidArgumentException
+	 * @return int
 	 */
 	public function getEqualityFieldValue( DataValue $value ) {
 		if ( !( $value instanceof BooleanValue ) ) {
 			throw new InvalidArgumentException( 'Value is not a BooleanValue.' );
 		}
 
-		return $value->getValue();
+		return $value->getValue() ? 1 : 0;
 	}
 
 }


### PR DESCRIPTION
This succeeds with MySQL and SQLite but fails with PostgreSQL. See https://travis-ci.org/wmde/WikibaseQueryEngine/jobs/42077613. Yes, this is probably a bug in DBAL but if there is a simple workaround, why not use it? I'm sure using ints instead of booleans (note that `false` becomes an empty string in PHP) is the most compatible way.

Wikibase\QueryEngine\QueryEngineException: An exception occurred while executing '`INSERT INTO qr_mainsnak_boolean (subject_id, subject_type, property_id, statement_rank, value) VALUES (?, ?, ?, ?, ?)`' with params `["Q20", "item", "P7701", 1, false]`:

SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type boolean: ""
