### PR TITLE
Don't allow HHVM build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ matrix:
       php: 5.6
   exclude:
     - env: THENEEDFORTHIS=FAIL
-  allow_failures:
-    - php: hhvm
 
 before_script:
   - composer install --prefer-source


### PR DESCRIPTION
As the build is passing now, there is no reason to have it in
allowed_failures.
